### PR TITLE
chore: update node engine to >=24 for active LTS

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "prettier": "^3.x"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "packageManager": "pnpm@10.33.0"
 }


### PR DESCRIPTION
## Summary
- Update node engine requirement from `>=20` to `>=24` to target Node.js 24 active LTS

## Test plan
- [x] Verify CI passes with Node 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)