### PR TITLE
fix(build): emit declaration files during build

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm', 'cjs'],
+  dts: true,
   sourcemap: true,
 });


### PR DESCRIPTION
## Summary

Enable declaration output in `tsdown.config.ts` so the published package includes the declaration files already referenced by the package export map.

The current package exports point TypeScript to:

- `./dist/index.d.cts` for `require`
- `./dist/index.d.mts` for `import`

but the published package only includes the JS bundles and maps, so typed consumers currently get TS7016.

## Verification

Published `@stzhu/prettier-plugin-tsconfig@0.7.3` in a clean consumer project:

```text
index.ts(1,20): error TS7016: Could not find a declaration file for module '@stzhu/prettier-plugin-tsconfig'.
```

After this change:

- `pnpm build` emits `dist/index.d.cts` and `dist/index.d.mts`
- `pnpm test` passes
- `pnpm pack` includes both declaration files
- installing the packed tarball into a clean consumer project and running `npx tsc --noEmit` passes