### PR TITLE
docs: add installation and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,40 +53,10 @@ The plugin automatically applies to any file matching `tsconfig.json`,
 `jsconfig.json`, or a variant such as `tsconfig.build.json` /
 `jsconfig.base.json`. No other JSON files are affected.
 
-## Example
+To format every config file in your project, use a glob:
 
-Before:
-
-```json
-{
-  "include": ["src/**/*"],
-  "compilerOptions": {
-    "strict": true,
-    "outDir": "./dist",
-    "target": "ESNext",
-    "module": "NodeNext",
-    "esModuleInterop": true
-  },
-  "exclude": ["node_modules"],
-  "extends": "./tsconfig.base.json"
-}
-```
-
-After:
-
-```json
-{
-  "extends": "./tsconfig.base.json",
-  "include": ["src/**/*"],
-  "exclude": ["node_modules"],
-  "compilerOptions": {
-    "strict": true,
-    "module": "NodeNext",
-    "outDir": "./dist",
-    "esModuleInterop": true,
-    "target": "ESNext"
-  }
-}
+```sh
+prettier -w '**/{ts,js}config{,.?*}.json'
 ```
 
 ## Generating sort order map

--- a/README.md
+++ b/README.md
@@ -2,6 +2,93 @@
 
 Prettier plugin to sort tsconfig.json files.
 
+It hooks into Prettier's JSON formatting and reorders the keys in `tsconfig.json`
+and `jsconfig.json` files to follow the order used by the official
+[TSConfig Reference](https://www.typescriptlang.org/tsconfig). Keys that aren't
+in the reference are kept and sorted alphabetically at the end.
+
+## Installation
+
+```sh
+pnpm add -D @stzhu/prettier-plugin-tsconfig
+```
+
+```sh
+npm install -D @stzhu/prettier-plugin-tsconfig
+```
+
+```sh
+yarn add -D @stzhu/prettier-plugin-tsconfig
+```
+
+Prettier `3.x` is required (it's a peer dependency).
+
+## Usage
+
+Add the plugin to your [Prettier configuration](https://prettier.io/docs/configuration).
+
+`.prettierrc.json`:
+
+```json
+{
+  "plugins": ["@stzhu/prettier-plugin-tsconfig"]
+}
+```
+
+`prettier.config.js`:
+
+```js
+export default {
+  plugins: ['@stzhu/prettier-plugin-tsconfig'],
+};
+```
+
+Then run Prettier as usual:
+
+```sh
+prettier --write tsconfig.json
+```
+
+The plugin automatically applies to any file matching `tsconfig.json`,
+`jsconfig.json`, or a variant such as `tsconfig.build.json` /
+`jsconfig.base.json`. No other JSON files are affected.
+
+## Example
+
+Before:
+
+```json
+{
+  "include": ["src/**/*"],
+  "compilerOptions": {
+    "strict": true,
+    "outDir": "./dist",
+    "target": "ESNext",
+    "module": "NodeNext",
+    "esModuleInterop": true
+  },
+  "exclude": ["node_modules"],
+  "extends": "./tsconfig.base.json"
+}
+```
+
+After:
+
+```json
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "strict": true,
+    "module": "NodeNext",
+    "outDir": "./dist",
+    "esModuleInterop": true,
+    "target": "ESNext"
+  }
+}
+```
+
 ## Generating sort order map
 
 ```

--- a/README.md
+++ b/README.md
@@ -2,10 +2,7 @@
 
 Prettier plugin to sort tsconfig.json files.
 
-It hooks into Prettier's JSON formatting and reorders the keys in `tsconfig.json`
-and `jsconfig.json` files to follow the order used by the official
-[TSConfig Reference](https://www.typescriptlang.org/tsconfig). Keys that aren't
-in the reference are kept and sorted alphabetically at the end.
+It hooks into Prettier's JSON formatting and reorders the keys in `tsconfig.json` and `jsconfig.json` files to follow the order used by the official [TSConfig Reference](https://www.typescriptlang.org/tsconfig). Keys that aren't in the reference are kept and sorted alphabetically at the end.
 
 ## Installation
 


### PR DESCRIPTION
## Summary

The README only documented how to regenerate the sort order map, with nothing on how to actually use the plugin. This adds user-facing docs:

- **Installation** for pnpm / npm / yarn, noting the Prettier `3.x` peer dependency.
- **Usage** — registering the plugin in `.prettierrc.json` / `prettier.config.js` and running Prettier.
- Which files the plugin applies to (`tsconfig.json`, `jsconfig.json`, and variants like `tsconfig.build.json`).
- A **before/after** example showing the resulting key order.

The existing "Generating sort order map" section is preserved.

## Test plan

- Built the plugin and ran `prettier --write` against sample `tsconfig.json` files via CLI (bare name, `./`-prefixed, and directory glob) — all sort as documented.
- The before/after example in the README is the verbatim output of the plugin on the "before" input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)